### PR TITLE
Feature: Implement Dynamic, Confidence-Based Position Sizing for Risk-Adjusted Trading

### DIFF
--- a/createPosition.ts
+++ b/createPosition.ts
@@ -6,7 +6,12 @@ import { API_KEY_INDEX, BASE_URL } from "./config";
 import { MARKETS } from "./markets";
 import { CandlestickApi, MarketInfo } from "./lighter-sdk-ts/generated";
 
-export async function createPosition(account: Account, symbol: string, side: "LONG" | "SHORT", quantity: number) {
+export async function createPosition(account: Account, symbol: string, side: "LONG" | "SHORT", notionalDollarAmount: number) {
+    if (notionalDollarAmount <= 0) {
+        console.log(`[TradeSkipped] Notional amount is $0.00. (AI Confidence was near 0.0)`);
+        return; 
+    }
+    
     const client = await SignerClient.create({
         url: BASE_URL,
         privateKey: account.apiKey,
@@ -22,15 +27,27 @@ export async function createPosition(account: Account, symbol: string, side: "LO
         middleware: [],
         authMethods: {}
     }); 
+    
     const candleStickData = await candleStickApi.candlesticks(market.marketId, '1m', Date.now() - 1000 * 60 * 5, Date.now(), 1, false);
     const latestPrice = candleStickData.candlesticks[candleStickData.candlesticks.length - 1]?.close;
+
     if (!latestPrice) {
-        throw new Error("No latest price found");
+        throw new Error(`No latest price found for ${symbol}. Cannot calculate trade quantity.`);
     }
+
+    const unitQuantity = notionalDollarAmount / latestPrice;
+    
+    if (unitQuantity * market.qtyDecimals <= 0) {
+        console.log(`[TradeSkipped] Calculated unit quantity (${unitQuantity.toFixed(4)}) is too small after conversion.`);
+        return;
+    }
+
+    console.log(`[TRADE] Notional: $${notionalDollarAmount.toFixed(2)}, Price: $${latestPrice.toFixed(2)}, Units: ${unitQuantity.toFixed(4)}`);
+    
     const response = await client.createOrder({
         marketIndex: market.marketId,
         clientOrderIndex: market.clientOrderIndex,
-        baseAmount: quantity * market.qtyDecimals,
+        baseAmount: unitQuantity * market.qtyDecimals,
         price: (side == "LONG" ? latestPrice * 1.01 : latestPrice * 0.99) * market.priceDecimals,
         isAsk: side == "LONG" ? false : true,
         orderType: SignerClient.ORDER_TYPE_MARKET,

--- a/prompt.ts
+++ b/prompt.ts
@@ -10,7 +10,20 @@ You can open positions in one of 3 markets
 2. HYPE (10x leverage)
 3. SOL (10x leverage)
 
-You can create leveraged positions as well, so feel free to chose higher quantities based on the leverage per market.
+// CRITICAL UPDATE: TRADING IS NOW RISK-ADJUSTED!
+// You DO NOT specify the raw quantity. Instead, you must specify your CONVICTION level.
+// Your **confidence score** (a number from 0.0 to 1.0) will be used to automatically 
+// determine the trade size (dollar amount) based on your available cash and a 
+// maximum risk limit.
+// A confidence of 1.0 will allocate the maximum allowed capital (highest risk/reward).
+// A confidence of 0.1 will allocate very little (lowest risk/reward).
+
+// Example of a HIGH-CONFIDENCE Long trade:
+// createPosition({ symbol: "ZEC-USD", side: "LONG", confidence: 0.95 })
+
+// Example of a LOW-CONFIDENCE Short trade:
+// createPosition({ symbol: "SOL-USD", side: "SHORT", confidence: 0.30 })
+// -----------------------------------------------------------------------
 
 You can only open one position at a time.
 You can close all open positions at once with the close_position tool. You CAN NOT close/edit individual positions. All existing positions must be cancelled at once. 


### PR DESCRIPTION
This PR upgrades the trading agent's position sizing mechanism from a static quantity model to a dynamic, risk-adjusted model based on the LLM's conviction.

The agent no longer directly outputs a trade quantity. Instead, it outputs a confidence score (0.0 to 1.0), which the system then uses to automatically calculate the precise notional dollar amount to allocate. This ensures that capital exposure is always proportional to the AI's perceived certainty, greatly enhancing risk management and capital efficiency.
Key Changes & Implementation Details
This feature required coordinated changes across three files:

1. Agent Logic & Risk Control (index.ts)
New Logic: Introduced calculateTradeSize, which enforces a maximum allocation percentage (e.g., 20% of available cash) and scales this amount linearly based on the AI's input confidence score.

Tool Schema Update: The createPosition tool's input schema was changed from requiring a raw quantity to requiring a mandatory confidence: z.number().min(0.0).max(1.0).

Auditing: The execution logic logs the AI's input confidence and the resulting calculatedTradeAmount into the ToolCalls metadata for deep performance analysis.

2. Execution & Market Conversion (createPosition.ts)
Input Change: The function signature now accepts the calculated notional dollar amount instead of the final unit quantity.

Market Price Fetch: The function fetches the current latestPrice from the 1m candlestick data.

Conversion Logic: The core logic converts the dollar amount to the required unit quantity before creating the order:
unityQuantity=notionalDollarAmount/latestPrice

The final order is placed using this calculated unit quantity for baseAmount.

3. LLM Instructions (prompt.ts)
Instructions Updated: The PROMPT was updated to explicitly tell the LLM to provide a confidence score (0.0 to 1.0) instead of a quantity when calling createPosition.